### PR TITLE
Fix build agent server address hardcode

### DIFF
--- a/recipes/build_agent.rb
+++ b/recipes/build_agent.rb
@@ -10,8 +10,8 @@ unless Chef::Config[:solo]
   end
 end
 
-unless node["teamcity_server"]["build_agent"]["server"]
-  Chef::Application.fatal! "Undefined TeamCity server address"
+if node["teamcity_server"]["build_agent"]["server"].nil?
+  node.default["teamcity_server"]["build_agent"]["server"] = node["ipaddress"]
 end
 
 properties_file     = "/opt/TeamCity/buildAgent/conf/buildAgent.properties"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,2 @@
-node.set["teamcity_server"]["build_agent"]["server"] = node["ipaddress"]
-
 include_recipe "teamcity_server::server"
 include_recipe "teamcity_server::build_agent"


### PR DESCRIPTION
There was no way to override `default["teamcity_server"]["build_agent"]["server"]` attribute because it was hardcoded ( for some strange reason, probably debugging? ) into the default recipe. That could cause build_agent registration failures, especially when you install teamcity on the default port 8111, which needs to be specified explicitly through the attribute.
