### PR TITLE
allow archive path to be configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,7 @@ default["teamcity_server"]["data_dir"]                          = "/opt/.BuildSe
 default["teamcity_server"]["user"]                              = "teamcity"
 default["teamcity_server"]["group"]                             = "teamcity"
 default["teamcity_server"]["home_dir"]                          = node["teamcity_server"]["root_dir"]
+default["teamcity_server"]["archive_path"]                      = nil
 
 default["teamcity_server"]["server"]["database_internal"]       = nil
 default["teamcity_server"]["server"]["database_connection_url"] = nil

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -33,7 +33,7 @@ end
 
 archive_name = "TeamCity-#{node["teamcity_server"]["version"]}.tar.gz"
 full_url     = "#{node["teamcity_server"]["base_url"]}#{archive_name}"
-archive      = "#{Chef::Config[:file_cache_path]}/#{archive_name}"
+archive      = node["teamcity_server"]["archive_path"].nil? ? "#{Chef::Config[:file_cache_path]}/#{archive_name}" : "#{node["teamcity_server"]["archive_path"]}/#{archive_name}"
 
 remote_file archive do
   backup false


### PR DESCRIPTION
Unfortunately Chef::Config[:file_cach_path] for aws opsworks is a directory that only can be accessed by the aws/opsworks user. This file_cache_path is not configurable: https://github.com/aws/opsworks-cookbooks/blob/master-chef-11.10/opsworks_commons/libraries/opsworks_instance_agent_config_parser.rb#L59

Allow the path to which the teamcity tgz is downloaded to be configurable, default to Chef::Config[:file_cache_path] if no archive_path attribute is provided.