### PR TITLE
handle multiple agents upstart

### DIFF
--- a/recipes/build_agent.rb
+++ b/recipes/build_agent.rb
@@ -92,7 +92,17 @@ template "/etc/init/teamcity-agent.conf" do
   variables(
       :user => node["teamcity_server"]["user"],
       :group => node["teamcity_server"]["group"],
-      :data_dir => node["teamcity_server"]["data_dir"],
+      :data_dir => node["teamcity_server"]["data_dir"]
+  )
+end
+
+template "/etc/init/teamcity-agents.conf" do
+  source "upstart/teamcity-agents.erb"
+  owner  "root"
+  group  "root"
+  variables(
+      :user => node["teamcity_server"]["user"],
+      :group => node["teamcity_server"]["group"],
       :root_dir => node["teamcity_server"]["root_dir"]
   )
 end

--- a/templates/default/upstart/teamcity-agent.erb
+++ b/templates/default/upstart/teamcity-agent.erb
@@ -1,13 +1,15 @@
 description "TeamCity Agent"
 
-start on runlevel [2345]
-stop on runlevel [06]
+# no "start on", we don't want to automatically start
+stop on (stopping teamcity-agents or runlevel [06])
 
 # TeamCity can take a while to shutdown
 kill timeout 30
 
 respawn
 respawn limit 15 5
+
+instance teamcity-agent-${processnum}
 
 setuid <%= @user %>
 setgid <%= @group %>
@@ -17,5 +19,14 @@ script
   if [ -f ~<%= @user %>/.bashrc ]; then
     . ~<%= @user %>/.bashrc
   fi
-  exec <%= @root_dir %>/agents/buildAgent/bin/agent.sh run
+  exec ${dir}bin/agent.sh run
+end script
+
+pre-stop script
+  export TEAMCITY_DATA_PATH=<%= @data_dir %>
+  if [ -f ~<%= @user %>/.bashrc ]; then
+    . ~<%= @user %>/.bashrc
+  fi
+
+  exec ${dir}bin/agent.sh stop
 end script

--- a/templates/default/upstart/teamcity-agents.erb
+++ b/templates/default/upstart/teamcity-agents.erb
@@ -1,0 +1,14 @@
+description "Manages TeamCity build agent processes"
+
+# This starts upon bootup and stops on shutdown
+start on runlevel [2345]
+stop on runlevel [06]
+
+env PROCESS_NUM=0
+
+pre-start script
+  for d in <%= @root_dir %>/agents/*/ ; do
+    start teamcity-agent dir=$d processnum=$PROCESS_NUM
+    PROCESS_NUM=$((PROCESS_NUM + 1))
+  done
+end script


### PR DESCRIPTION
The cookbook supports installation of multiple agents, but only supports starting one agent. This PR contains a `teamcity-agents.conf` upstart script that will start all the agents installed in the <root_dir>/agents directory

To use, simply run `service teamcity-agents start`