### PR TITLE
Add TeamCity server startup options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,9 @@ default["teamcity_server"]["user"]                              = "teamcity"
 default["teamcity_server"]["group"]                             = "teamcity"
 default["teamcity_server"]["home_dir"]                          = node["teamcity_server"]["root_dir"]
 default["teamcity_server"]["archive_path"]                      = nil
+default["teamcity_server"]["server_opts"]                       = nil
+default["teamcity_server"]["server_mem_opts"]                   = nil
+default["teamcity_server"]["server_prepare_script"]             = nil
 
 default["teamcity_server"]["server"]["database_internal"]       = nil
 default["teamcity_server"]["server"]["database_connection_url"] = nil

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -32,6 +32,9 @@ template "/etc/init/teamcity-server.conf" do
   variables(
       :user => node["teamcity_server"]["user"],
       :group => node["teamcity_server"]["group"],
+      :server_opts => node["teamcity_server"]["server_opts"],
+      :server_mem_opts => node["teamcity_server"]["server_mem_opts"],
+      :prepare_script => node["teamcity_server"]["server_prepare_script"],
       :data_dir => node["teamcity_server"]["data_dir"],
       :root_dir => node["teamcity_server"]["root_dir"]
   )

--- a/templates/default/upstart/teamcity-server.erb
+++ b/templates/default/upstart/teamcity-server.erb
@@ -13,6 +13,9 @@ setuid <%= @user %>
 setgid <%= @group %>
 
 script
+  export TEAMCITY_SERVER_MEM_OPTS=<%= @server_mem_opts %>
+  export TEAMCITY_SERVER_OPTS=<%= @server_opts %>
   export TEAMCITY_DATA_PATH=<%= @data_dir %>
+  export TEAMCITY_PREPARE_SCRIPT=<%= @prepare_script %>
   exec <%= @root_dir %>/bin/teamcity-server.sh run
 end script

--- a/templates/default/upstart/teamcity-server.erb
+++ b/templates/default/upstart/teamcity-server.erb
@@ -13,9 +13,9 @@ setuid <%= @user %>
 setgid <%= @group %>
 
 script
-  export TEAMCITY_SERVER_MEM_OPTS=<%= @server_mem_opts %>
-  export TEAMCITY_SERVER_OPTS=<%= @server_opts %>
-  export TEAMCITY_DATA_PATH=<%= @data_dir %>
-  export TEAMCITY_PREPARE_SCRIPT=<%= @prepare_script %>
+  export TEAMCITY_SERVER_MEM_OPTS="<%= @server_mem_opts %>"
+  export TEAMCITY_SERVER_OPTS="<%= @server_opts %>"
+  export TEAMCITY_DATA_PATH="<%= @data_dir %>"
+  export TEAMCITY_PREPARE_SCRIPT="<%= @prepare_script %>"
   exec <%= @root_dir %>/bin/teamcity-server.sh run
 end script


### PR DESCRIPTION
Adds environment variables accepted by teamcity startup scripts.

There's similar options for agents, but waiting for #8 to be resolved.